### PR TITLE
feat: 메모 수정기능 구현

### DIFF
--- a/src/components/Card/CardWrapper/index.tsx
+++ b/src/components/Card/CardWrapper/index.tsx
@@ -23,7 +23,7 @@ interface CardWrapperProps {
 }
 
 export default function CardWrapper({ card }: CardWrapperProps) {
-  // console.log(card);
+  console.log(card);
 
   const { modalOpen, openModal, closeModal } = useModal();
   const queryClient = useQueryClient();

--- a/src/components/Card/CardWrapper/index.tsx
+++ b/src/components/Card/CardWrapper/index.tsx
@@ -23,8 +23,6 @@ interface CardWrapperProps {
 }
 
 export default function CardWrapper({ card }: CardWrapperProps) {
-  console.log(card);
-
   const { modalOpen, openModal, closeModal } = useModal();
   const queryClient = useQueryClient();
   const { mutate: del } = useMutation(deleteMemo, {
@@ -37,11 +35,15 @@ export default function CardWrapper({ card }: CardWrapperProps) {
     },
   });
   const [showDeleteButton, setShowDeleteButton] = useState(false);
-  const { value, onChange } = useInput();
+  const { value: content, onChange: onContentChange } = useInput();
+  console.log(content);
 
   const handleDotClick = () => {
     setShowDeleteButton(true);
-    modifyMemo({ content: "test", id: 12 });
+    onContentChange({ target: { value: card.content } });
+  };
+  const handleModify = () => {
+    modifyMemo({ content, id: card.id });
   };
   const handleDelete = () => {
     console.log(card.id);
@@ -57,14 +59,14 @@ export default function CardWrapper({ card }: CardWrapperProps) {
         {showDeleteButton ? (
           <S.ButtonWrapper>
             <Button type="TAG" text={"삭제"} />
-            <Button type="TAG" text={"완료"} />
+            <Button type="TAG" text={"완료"} onClick={handleModify} />
           </S.ButtonWrapper>
         ) : (
           <Dot onClick={handleDotClick} />
         )}
       </S.MenuWrapper>
       {showDeleteButton ? (
-        <S.ModifyTextArea value={"잠시"} placeholder={"대기"} />
+        <S.ModifyTextArea value={content} onChange={onContentChange} />
       ) : (
         <>
           {card && isTextMemo(card) && (
@@ -99,7 +101,7 @@ export default function CardWrapper({ card }: CardWrapperProps) {
           ))}
         </S.TagsBtnWrapper>
         <S.ModifyBtnWrapper2>
-          <Button type="TAG_ADD" text={"..."} />
+          <Button type="TAG_ADD" text={"…"} />
           {showDeleteButton && <S.AddTagBtn />}
         </S.ModifyBtnWrapper2>
       </S.TagWrapper>


### PR DESCRIPTION
## [❓ 무엇을 위한 PR인가요?]

- 메모 수정기능 구현

## [⭐️ 작업 내용]

- 수정 api 패칭하여 기능 구현

## [📌 제안 및 안내 사항]
- 수정 버튼을 누르면 메모가 저장하고 있던 text를 불러와 textAerea에 value 띄운 후 수정이 가능합니다.
- 수정 완료 버튼을 누르면 메모수정 API가 패칭되어 수정이 가능하게 됩니다.
- 완료 버튼 클릭 후 UI 가 변경될 수 있도록 로직 구현이 필요합니다.
## [📢 스크린샷]

수정 기능 활성화
<img width="653" alt="image" src="https://github.com/TeoSprint15-10/NAVOGUE-FE/assets/89332492/c2722c59-105d-49a5-922a-e59a2df7082e">

수정 완료
<img width="472" alt="image" src="https://github.com/TeoSprint15-10/NAVOGUE-FE/assets/89332492/a57543c5-4ac1-4f7f-b92d-61fe3866918e">



## [issue number]

- issue에 작성된 작업이 모두 완료되었다면 close 해주세요.
  ex) close : #64  
